### PR TITLE
Add autoload to flycheck-falco-rules-setup

### DIFF
--- a/flycheck-falco-rules.el
+++ b/flycheck-falco-rules.el
@@ -95,6 +95,7 @@ about Falco."
   
   :modes '(yaml-mode))
 
+;;;###autoload
 (defun flycheck-falco-rules-setup ()
   "Set up Flycheck for Falco Rules files."
   (add-to-list 'flycheck-checkers 'falco-rules))


### PR DESCRIPTION
This allows it to be added to the flycheck after load hook.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>